### PR TITLE
feat: add header scroll animation

### DIFF
--- a/src/components/Header/index.astro
+++ b/src/components/Header/index.astro
@@ -2,7 +2,34 @@
 
 ---
 
-<header class="bg-white mb-12">
+<script>
+  let lastScrollY = 0;
+  let translateY = 0;
+
+  const handleScroll = () => {
+    const currentScrollY = window.scrollY;
+    const header = document.querySelector("header");
+    const height = header?.offsetHeight ?? 0;
+
+    const scrollDirection = currentScrollY > lastScrollY ? "down" : "up";
+    const scrollDistance = Math.abs(currentScrollY - lastScrollY);
+
+    if (scrollDirection === "down") {
+      translateY = Math.max(-height, translateY - scrollDistance);
+    } else {
+      translateY = Math.min(0, translateY + scrollDistance);
+    }
+
+    lastScrollY = currentScrollY;
+
+    if (header) {
+      header.style.transform = `translateY(${translateY}px)`;
+    }
+  };
+
+  window.addEventListener("scroll", handleScroll);
+</script>
+<header class="bg-white sticky top-0 z-50" style={`transform: translateY(0px);`}>
   <div
     class="container max-w-4xl mx-auto flex justify-between items-center py-4 px-8"
   >

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,7 @@ const { title = SITE_TITLE, description = SITE_DESCRIPTION } = Astro.props;
   <body>
     <div class="flex flex-col min-h-screen">
       <Header />
-      <main class="flex-grow">
+      <main class="flex-grow mt-12">
         <slot />
       </main>
       <Footer />


### PR DESCRIPTION
블로그 글을 보다가 홈으로 가고 싶을 때 최상단 까지 스크롤 해야하는 불편함을 해소하기 위해 위로 스크롤하면 header가 노출되도록 하였습니다. header를 상시 노출시키는 방법은 블로그 글에 집중되지 못할 것이라고 생각했기에 해당 방식을 채택하였습니다.